### PR TITLE
Support running container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ USER appuser
 WORKDIR /app
 
 COPY Pipfile* /app/
-COPY *.py /app/
-COPY LICENSE /app/
+COPY *.py LICENSE /app/
 
 RUN pip install --no-cache-dir pipenv
 RUN /app/.local/bin/pipenv install --system --deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ USER 65532
 
 WORKDIR /app
 
-COPY Pipfile* /app/
-COPY *.py LICENSE /app/
+COPY Pipfile* *.py LICENSE /app/
 
 RUN pip install --no-cache-dir pipenv
 RUN /app/.local/bin/pipenv install --system --deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
-RUN useradd -d /app -m appuser
-USER appuser
+RUN useradd -u 65532 -d /app -m appuser
+USER 65532
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM python:3.8-slim
-RUN pip install --no-cache-dir pipenv
+
+RUN useradd -d /app -m appuser
+USER appuser
+
 WORKDIR /app
+
 COPY Pipfile* /app/
-RUN cd /app && \
-    pipenv install --system --deploy
+COPY *.py /app/
+COPY LICENSE /app/
+
+RUN pip install --no-cache-dir pipenv
+RUN /app/.local/bin/pipenv install --system --deploy
 # Maybe "pipenv sync" would be better. I'm unsure:
 # https://pipenv-fork.readthedocs.io/en/latest/advanced.html#using-pipenv-for-deployments
-COPY * /app/
+
 EXPOSE 8080 9090
 ENV prometheus_multiproc_dir=/tmp
-CMD ["gunicorn", "-c", "gunicorn_conf.py", "server:app"]
+CMD ["/app/.local/bin/gunicorn", "-c", "gunicorn_conf.py", "server:app"]


### PR DESCRIPTION
This PR allows running the container as non-root, to support restrictive PSPs.

* Create a non-root runtime user
* Specify execution paths explicitly
* Install only files needed by the application into the container